### PR TITLE
Fixing issue with non-delegated .on() (fixes #17)

### DIFF
--- a/sprint.js
+++ b/sprint.js
@@ -1138,7 +1138,8 @@
     },
     on: function(events, selector, handler) {
       if(typeof selector !== "string"){
-        handler = selector
+        handler = selector;
+        selector = null;
       }
       // .on(events, handler)
       if (handler) {
@@ -1419,7 +1420,7 @@
   var Sprint = function(selector, context) {
     return new Init(selector, context)
   }
-  
+
   Sprint.fn = Init.prototype;
 
   if (typeof define === "function" && define.amd) {

--- a/sprint.min.js
+++ b/sprint.min.js
@@ -130,7 +130,7 @@ e.offset(i)}):void 0},offsetParent:function(){var t=[]
 return this.each(function(){if(!(this.nodeType>1)){for(var n=this;n!=b;){n=n.parentNode
 var e=getComputedStyle(n).getPropertyValue("position")
 if(!e)break
-if("static"!=e)return void t.push(n)}t.push(b)}}),M(t)},on:function(t,n,i){if("string"!=typeof n&&(i=n),i){n&&(i=e(i,n))
+if("static"!=e)return void t.push(n)}t.push(b)}}),M(t)},on:function(t,n,i){if("string"!=typeof n&&(i=n,n=null),i){n&&(i=e(i,n))
 var r=t.trim().split(" ")
 return this.each(function(){n&&(i=e(i,n,this)),f(this)||(this.sprintEventListeners={}),r.forEach(function(t){f(this)[t]||(f(this)[t]=[]),f(this)[t].push(i),this.addEventListener(t,i),p(t)&&this.addEventListener(u(t),i)},this)})}return Object.keys(t).forEach(function(n){this.on(n,t[n])},this),this},parent:function(t){return s.call(this,!0,!0,!1,t)},parents:function(t){return s.call(this,!0,!1,!1,t)},position:function(){var t={first:this.offset(),prt:this.parent().offset()}
 if(t.first)return{top:t.first.top-t.prt.top,left:t.first.left-t.prt.left}},prop:function(t,n){if("object"==typeof t){var e=Object.keys(t),i=e.length


### PR DESCRIPTION
This should fix issue #17, whereby directly binding an event to an element using `$(…).on(event, handler)` doesn’t work, but using a delegate handler (`$(…).on(event, selector, handler)`) does.

There is a test/demo available here: https://jsfiddle.net/jonpearse/oc1w7hfy/